### PR TITLE
refactor: Fix size check in enqueue method to solve issue #20

### DIFF
--- a/code/chapter03/queue.rs
+++ b/code/chapter03/queue.rs
@@ -17,7 +17,7 @@ impl<T> Queue<T> {
 
     // 判断是否有剩余空间、有则数据加入队列
     fn enqueue(&mut self, val: T) -> Result<(), String> {
-        if Self::size(&self) == self.cap {
+        if self.size() == self.cap {
             return Err("No space available".to_string());
         }
         self.data.insert(0, val);


### PR DESCRIPTION
Fix the size check because the function of "size(&self) " is a method belongs to one instance, so that we can't use the Self::size(&self) to obtain the size of self, the better choice is using self.size() to fix the issue #20